### PR TITLE
Removing duplicate property from css file

### DIFF
--- a/client/src/components/LinkDisplay/Style.module.css
+++ b/client/src/components/LinkDisplay/Style.module.css
@@ -21,7 +21,6 @@
 .linkTextArea {
   width: 100%;
   border-width: 0px;
-  font-family: inherit;
   font-size: 18px;
   outline: none;
   resize: none;


### PR DESCRIPTION
Properties should not be duplicated, 

Removing font-family: inherit; from Style.module.css file.