### PR TITLE
fix: allow user to remove image attachment #118

### DIFF
--- a/client/src/components/Messaging/ImagePicker/index.js
+++ b/client/src/components/Messaging/ImagePicker/index.js
@@ -7,12 +7,17 @@ import styles from './Style.module.css';
 const ImagePicker = (props) => {
   const { selectedImg, setSelectedImg, setText, previewImg, setPreviewImg } = props;
   const selectImage = async (e) => {
+    // maintain the property reference after event callback in order to clean up
+    e.persist();
     const { base64: imgUrl, fileName } = await imagePicker(e);
     if (imgUrl) {
       setPreviewImg(true);
       setSelectedImg(imgUrl);
       setText(fileName);
     }
+    // clean up the targeted HTML element to render
+    // else html sense no change and not render if you choose same image after cancelation once
+    e.target.value = '';
   };
 
   return (

--- a/client/src/components/Messaging/NewMessageForm.js
+++ b/client/src/components/Messaging/NewMessageForm.js
@@ -2,8 +2,10 @@ import React, { useRef, useContext } from 'react';
 import styles from './styles/NewMessageForm.module.css';
 import { ThemeContext } from '../../ThemeContext.js';
 import ImagePicker from './ImagePicker';
+import RemoveButton from './RemoveButton';
 import EmojiRow from './EmojiRow';
 import detectMobile from '../../utils/detectMobile.js';
+
 export const NewMessageForm = ({
   handleSubmit,
   text,
@@ -11,7 +13,8 @@ export const NewMessageForm = ({
   selectedImg,
   setSelectedImg,
   previewImg,
-  setPreviewImg
+  setPreviewImg,
+  resetImage
 }) => {
   const inputRef = useRef(null);
   const [darkMode] = useContext(ThemeContext);
@@ -38,6 +41,7 @@ export const NewMessageForm = ({
             onChange={(e) => setText(e.target.value)}
             value={text}
           />
+          {selectedImg === '' ? null : <RemoveButton onClick={resetImage} />}
           <div className={styles.buttonImageContainer}>
             <div className={styles.imagePickerContainer}>
               <ImagePicker

--- a/client/src/components/Messaging/RemoveButton/Style.module.css
+++ b/client/src/components/Messaging/RemoveButton/Style.module.css
@@ -1,0 +1,40 @@
+.removeButtonContainer {
+  margin: auto;
+  width: 50px;
+  height: 50px;
+}
+
+.checkmark {
+  width: 30px;
+  height: 30px;
+  margin: 10px;
+}
+
+.darkMode {
+  color: #fff;
+  background: #000;
+}
+
+.checkmark:hover {
+  cursor: pointer;
+  animation: growIn 0.3s forwards;
+}
+
+.lightMode {
+  color: #231709;
+  background: #e2e2e2;
+}
+
+@keyframes growIn {
+  0% {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  100% {
+    -webkit-transform: scale(1.1);
+    -ms-transform: scale(1.1);
+    transform: scale(1.1);
+  }
+}

--- a/client/src/components/Messaging/RemoveButton/index.js
+++ b/client/src/components/Messaging/RemoveButton/index.js
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+import styles from './Style.module.css';
+import { IoMdCloseCircleOutline } from 'react-icons/io';
+import { ThemeContext } from '../../../../src/ThemeContext';
+
+const RemoveButton = ({ onClick }) => {
+  const [darkMode] = useContext(ThemeContext);
+  return (
+    <div
+      className={`${styles.removeButtonContainer} 
+    ${darkMode === true ? styles.darkMode : styles.lightMode}`}
+    >
+      <IoMdCloseCircleOutline className={styles.checkmark} onClick={onClick} />
+    </div>
+  );
+};
+
+export default RemoveButton;

--- a/client/src/pages/messaging/index.js
+++ b/client/src/pages/messaging/index.js
@@ -93,7 +93,10 @@ const Chat = () => {
         local: true
       })
     );
+    resetImageHandler();
+  };
 
+  const resetImageHandler = () => {
     setSelectedImg('');
     setPreviewImg(false);
     setText('');
@@ -253,6 +256,7 @@ const Chat = () => {
           setSelectedImg={setSelectedImg}
           previewImg={previewImg}
           setPreviewImg={setPreviewImg}
+          resetImage={resetImageHandler}
         />
       </div>
       <Notification play={notificationState} audio={notificationAudio} />


### PR DESCRIPTION
I'm not *officially* assigned, but hope my contribution helps anywayヽ(✿ﾟ▽ﾟ)ノ.

1. follow the "convention" 

- the svg button follows the convention using svg element----'react-icons/io'. 

- change the color according to dark mode / light mode

2. the hover effect of "grow-in" may not be necessary, just add some spice, feel free to remove if too confusing

3. e.persist() in client/src/components/Messaging/ImagePicker/index.js seems to solve the crash of the ImagePicker's index.js in utils when we click the imagePicker with cancellation (i.e. without choosing anything). The crash is only visible in development.

4. The stroke might not be adjusted as small as drawn in the Issues. Maybe workable if adjust the svg path instead using the checkbox svg of the react-icons/io directly. But it might be too tedious and break the "convention" using svg/icon library.