### PR TITLE
fix: prevent default on the submit form

### DIFF
--- a/client/src/components/Messaging/NewMessageForm.tsx
+++ b/client/src/components/Messaging/NewMessageForm.tsx
@@ -39,6 +39,13 @@ export const NewMessageForm = ({
     handleSubmit(event);
   };
 
+  const handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleSubmit(event);
+    }
+  };
+
   return (
     <form
       className={`${styles.sendMessageForm} ${!darkMode && styles.lightsendMessageForm}`}
@@ -61,6 +68,7 @@ export const NewMessageForm = ({
             onChange={(e) => setText(e.target.value)}
             value={text}
             autoComplete="off"
+            onKeyPress={handleKeyPress}
           />
           {selectedImg === "" ? null : <RemoveButton onClick={resetImage} />}
           <div className={styles.buttonImageContainer}>


### PR DESCRIPTION
Regarding issue [#328](https://github.com/muke1908/chat-e2ee/issues/328), I encountered an issue where typing a message and pressing "Enter" would cause the page to reload, resulting in the deletion of messages. I invested a considerable amount of time understanding the project flow and how the message sending function was triggered.

After conducting thorough research, I realized that when creating forms in a React environment, it's crucial to utilize the "event.preventDefault()" method. This method serves to prevent the default form submission behavior, which otherwise leads to an automatic page reload.

To address this issue, I devised a new method called "handleKeyPress." This method serves two essential purposes: firstly, it prevents the undesirable automatic form submission behavior, and secondly, it invokes the "handleSubmit" function to effectively send the message.