### PR TITLE
fixed Docker container

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,98 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '43 11 * * *'
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,6 +76,7 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: .
+          file: docker/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/client/src/pages/messaging/index.tsx
+++ b/client/src/pages/messaging/index.tsx
@@ -21,6 +21,11 @@ if(process.env.NODE_ENV === 'development') {
     apiURL: 'http://localhost:3000',
     socketURL: 'http://localhost:3000',
   })
+} else {
+setConfig({
+    apiURL: `${location.protocol}//${location.hostname}` ,
+    socketURL: `${location.protocol}//${location.hostname}`  ,
+  })
 }
 
 const chate2ee = createChatInstance();

--- a/client/src/pages/messaging/index.tsx
+++ b/client/src/pages/messaging/index.tsx
@@ -23,8 +23,8 @@ if(process.env.NODE_ENV === 'development') {
   })
 } else {
 setConfig({
-    apiURL: `${location.protocol}//${location.hostname}` ,
-    socketURL: `${location.protocol}//${location.hostname}`  ,
+    apiURL: `${window.location.protocol}//${window.location.hostname}` ,
+    socketURL: `${window.location.protocol}//${window.location.hostname}`  ,
   })
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,19 @@
 FROM node:lts-alpine
-#Set production mode deployment
-ENV NODE_ENV "production"
+
 WORKDIR /chat-e2ee
-# todo break apart client and server dep installs/builds
+# todo break apart client and server dep installs/builds so that they can be cached b/w builds
 COPY . /chat-e2ee/ 
 
 RUN npm install 
 
-RUN npm run build --unsafe-perm
+RUN npm run build
 
 # todo - multi part build (lets us slim down container to not unclude all the webpack stuff)
 
 RUN rm .env.sample
 
-EXPOSE 3000
+EXPOSE 3001
 USER node
-
+#Set production mode deployment
+ENV NODE_ENV "production"
 ENTRYPOINT [ "npm", "run", "docker_start" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,9 @@
 FROM node:lts-alpine
 #Set production mode deployment
 ENV NODE_ENV "production"
+WORKDIR /chat-e2ee
+COPY package*.json /chat-e2ee/
 
-COPY package*.json /chat-e2ee
-
-WORKDIR /chat-e2ee 
 
 RUN npm install 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ COPY . /chat-e2ee/
 
 RUN npm install 
 
-RUN npm run build 
+RUN npm run build --unsafe-perm
 
 # todo - multi part build (lets us slim down container to not unclude all the webpack stuff)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,23 @@
-FROM node:12.18.3-buster
-
+FROM node:lts-alpine
 #Set production mode deployment
 ENV NODE_ENV "production"
+
+COPY package*.json /chat-e2ee
+
+WORKDIR /chat-e2ee 
+
+RUN npm install 
 
 #copy the content of current directory to /app inside container
 COPY . /chat-e2ee
 
-WORKDIR /chat-e2ee 
-
-RUN npm install --unsafe-perm
-
 RUN npm run build 
 
+# todo - multi part build (lets us slim down container to not unclude all the webpack stuff)
+
 RUN rm .env.sample
+
+EXPOSE 3000
+USER node
 
 ENTRYPOINT [ "npm", "run", "docker_start" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,10 @@ FROM node:lts-alpine
 #Set production mode deployment
 ENV NODE_ENV "production"
 WORKDIR /chat-e2ee
-COPY package*.json /chat-e2ee/
-
+# todo break apart client and server dep installs/builds
+COPY . /chat-e2ee/ 
 
 RUN npm install 
-
-#copy the content of current directory to /app inside container
-COPY . /chat-e2ee
 
 RUN npm run build 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,6 +16,10 @@ From the project root directory, issue the following command :
 docker build . -f docker/Dockerfile -t chat-e2e:latest
 ```
 
+##### Alternatively, there is a pre-built docker image
+
+it is available at ```ghcr.io/muke1908/chat-e2ee:master``` 
+
 ##### Running the docker container
 
 1. Create a .env file

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "cross-env NODE_ENV=test jest",
     "start": "cross-env NODE_ENV=production npm run serve",
     "postinstall": "npm run build-service-sdk && cd client && npm install",
-    "docker_start": "cross-env NODE_ENV=production node index",
+    "docker_start": "cross-env NODE_ENV=production node ./dist/index",
     "build-service-sdk": "cd service && npm install && npm run build",
     "publish-sdk": "cd service && npm run publish-sdk"
   },


### PR DESCRIPTION
I was unable to run the docker container as it exists today in the repo. In order to fix it I:
1. upgraded the base image to lts-alpine (points to node 20 today) in order to slim down the container and keeping the node version up to date
2. moved some commands around in the Dockerfile so that it builds (was failing with ```sh: webpack command not found`)```
3. run the Docker container as node user (instead of root)
4. left some random future upgrade options to improve the container
5. fixed the  docker_start script

additionally, I included the default GitHub action script to build + publish the container to the GitHub repo. this could be removed from the PR if not desired

# testing
built + ran the Docker container  