### PR TITLE
slimmed down docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.github
+.vscode
+client/build
+client/node_modules
+service/dist
+service/node_modules

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:lts-alpine as BUILD
 
 WORKDIR /chat-e2ee
 # todo break apart client and server dep installs/builds so that they can be cached b/w builds
@@ -10,10 +10,21 @@ RUN npm run build
 
 # todo - multi part build (lets us slim down container to not unclude all the webpack stuff)
 
-RUN rm .env.sample
+FROM node:lts-alpine
+
+WORKDIR /chat-e2ee
+COPY package*.json /chat-e2ee/
+RUN mkdir -p /chat-e2ee/client/build
+COPY --from=BUILD  /chat-e2ee/dist /chat-e2ee/dist
+COPY --from=BUILD /chat-e2ee/client/build /chat-e2ee/client/build
+
+# dont install dev deps
+ENV NODE_ENV "production"
+# dont run scripts to avoid pulling all client build deps + stuff
+RUN npm ci --ignore-scripts=true --omit dev
 
 EXPOSE 3001
 USER node
 #Set production mode deployment
-ENV NODE_ENV "production"
+
 ENTRYPOINT [ "npm", "run", "docker_start" ]

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "form-data": "^3.0.0",
     "mongodb": "^4.17.0",
     "node-fetch": "^2.6.7",
-    "react-bootstrap": "^1.5.2",
-    "socket.io": "^4.5.4",
-    "ts-node": "^10.9.1",
-    "typescript": "5.0.4",
+    "socket.io": "^4.5.4",    
     "uuid": "^8.2.0"
   },
   "devDependencies": {
+    "react-bootstrap": "^1.5.2",
+    "ts-node": "^10.9.1",
+    "typescript": "5.0.4",
     "@commitlint/cli": "^17.3.0",
     "@commitlint/config-conventional": "^17.3.0",
     "@types/cors": "^2.8.12",


### PR DESCRIPTION
- use intern container to run webpack + ts build and then copy over the build results to final container
- moved some build deps over to devDeps to slim down runtime deps in final container
- added build + dep folders to docker ignore  (only matters for building locally, but asserts that only the built files are used in the container)