### PR TITLE
fix: prevent stored messages being reset in session storage

### DIFF
--- a/client/src/pages/messaging/index.tsx
+++ b/client/src/pages/messaging/index.tsx
@@ -67,7 +67,7 @@ const Chat = () => {
   }, [channelID, userId]);
 
   useEffect(() => {
-    if (LS.get("store-chat-messages")) {
+    if (LS.get("store-chat-messages") && messages.length > 0) {
       SS.set(`chat#${channelID}`, messages);
     }
   }, [channelID, messages]);


### PR DESCRIPTION
Add a "messages.length" check to prevent stored messages being reset when refreshing the page.
https://github.com/muke1908/chat-e2ee/pull/299#issuecomment-2277364720