### PR TITLE
fix: pointer always pops up when sending and receiving messages

### DIFF
--- a/client/src/components/Messaging/ScrollWrapper.tsx
+++ b/client/src/components/Messaging/ScrollWrapper.tsx
@@ -8,48 +8,52 @@ type ScrollWrapperProps = {
 
 export const ScrollWrapper = ({ children, messageCount }: ScrollWrapperProps) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
   const [showPopup, setShowPopup] = useState(false);
-  const [scrollAtBottom, setScrollAtBottom] = useState(true);
 
   useEffect(() => {
-    if (wrapperRef.current) {
+    const handleScroll = () => {
       const wrapper = wrapperRef.current;
-      const isScrolledToBottom = wrapper.scrollHeight - wrapper.scrollTop === wrapper.clientHeight;
-      setScrollAtBottom(isScrolledToBottom);
-      if (isScrolledToBottom) {
-        wrapper.scrollTop = wrapper.scrollHeight;
-      } else {
-        setShowPopup(true);
-      }
+      if (!wrapper) return;
+      setIsAtBottom(wrapper.scrollTop + wrapper.clientHeight >= wrapper.scrollHeight);
+    };
+
+ const wrapperElement = wrapperRef.current;
+    if (wrapperElement) {
+      wrapperElement.addEventListener('scroll', handleScroll);
     }
-  }, [messageCount]);
+
+    return () => {
+      if (wrapperElement) {
+        wrapperElement.removeEventListener('scroll', handleScroll);
+      }
+    };
+  }, []);
 
   useEffect(() => {
-    if (scrollAtBottom && wrapperRef.current) {
-      wrapperRef.current.scrollTop = wrapperRef.current.scrollHeight;
+    if (isAtBottom && messageCount > 0) {
+      scrollToBottom();
     }
-  }, [scrollAtBottom, messageCount]);
+  }, [messageCount, isAtBottom]);
+
+  useEffect(() => {
+    if (!isAtBottom && messageCount > 0) {
+      setShowPopup(true);
+    }
+// eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messageCount]);
 
   const scrollToBottom = () => {
     if (wrapperRef.current) {
       wrapperRef.current.scrollTop = wrapperRef.current.scrollHeight;
-      setShowPopup(false);
     }
-  };
-
-  const handleScroll = () => {
-    if (wrapperRef.current) {
-      const wrapper = wrapperRef.current;
-      const isScrolledToBottom = wrapper.scrollHeight - wrapper.scrollTop === wrapper.clientHeight;
-      setScrollAtBottom(isScrolledToBottom);
-      setShowPopup(false);
-    }
+    setShowPopup(false);
   };
 
   return (
-    <div className={styles.scrollWrapper} ref={wrapperRef} onScroll={handleScroll}>
+    <div className={styles.scrollWrapper} ref={wrapperRef}>
       {children}
-      {showPopup && !scrollAtBottom && (
+      {showPopup && (
         <div className={styles.popup} onClick={scrollToBottom}>
           New Messages
         </div>

--- a/client/src/components/Messaging/ScrollWrapper.tsx
+++ b/client/src/components/Messaging/ScrollWrapper.tsx
@@ -12,42 +12,38 @@ export const ScrollWrapper = ({ children, messageCount }: ScrollWrapperProps) =>
   const [showPopup, setShowPopup] = useState(false);
 
   useEffect(() => {
+    const wrapper = wrapperRef.current;
     const handleScroll = () => {
-      const wrapper = wrapperRef.current;
       if (!wrapper) return;
       setIsAtBottom(wrapper.scrollTop + wrapper.clientHeight >= wrapper.scrollHeight);
     };
 
- const wrapperElement = wrapperRef.current;
-    if (wrapperElement) {
-      wrapperElement.addEventListener('scroll', handleScroll);
+    if (wrapper) {
+      wrapper.addEventListener('scroll', handleScroll);
     }
 
     return () => {
-      if (wrapperElement) {
-        wrapperElement.removeEventListener('scroll', handleScroll);
+      if (wrapper) {
+        wrapper.removeEventListener('scroll', handleScroll);
       }
     };
   }, []);
 
   useEffect(() => {
-    if (isAtBottom && messageCount > 0) {
+    if (isAtBottom) {
       scrollToBottom();
-    }
-  }, [messageCount, isAtBottom]);
-
-  useEffect(() => {
-    if (!isAtBottom && messageCount > 0) {
+    } else {
       setShowPopup(true);
     }
 // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messageCount]);
 
   const scrollToBottom = () => {
-    if (wrapperRef.current) {
-      wrapperRef.current.scrollTop = wrapperRef.current.scrollHeight;
+    const wrapper = wrapperRef.current;
+    if (wrapper) {
+      setShowPopup(false);
+      wrapper.scrollTop = wrapper.scrollHeight;
     }
-    setShowPopup(false);
   };
 
   return (

--- a/client/src/components/Messaging/ScrollWrapper.tsx
+++ b/client/src/components/Messaging/ScrollWrapper.tsx
@@ -15,7 +15,13 @@ export const ScrollWrapper = ({ children, messageCount }: ScrollWrapperProps) =>
     const wrapper = wrapperRef.current;
     const handleScroll = () => {
       if (!wrapper) return;
-      setIsAtBottom(wrapper.scrollTop + wrapper.clientHeight >= wrapper.scrollHeight);
+      const atBottom = wrapper.scrollTop + wrapper.clientHeight >= wrapper.scrollHeight - 1;
+      setIsAtBottom(atBottom);
+
+      // Hide popup if scrolled to bottom
+      if (atBottom) {
+        setShowPopup(false);
+      }
     };
 
     if (wrapper) {


### PR DESCRIPTION
The "New Messages" pointer pops up both when sending messages continuously and receiving messages. https://github.com/muke1908/chat-e2ee/issues/77#issuecomment-2277770989

This patch fix it. But when sending and receiving messages very quickly, issues may still occur.

Changing `scroll-behavior: smooth;` to `scroll-behavior: auto;` in [client/src/components/Messaging/styles/ScrollWrapper.module.css](https://github.com/muke1908/chat-e2ee/blob/master/client/src/components/Messaging/styles/ScrollWrapper.module.css) can significantly alleviate the problem. 

However, considering the smoothness of the scrolling experience and the fact that only a few users will send or receive messages at such a high speed, no changes are made at this time.