### PR TITLE
style: fix QR button misalignment on mobile browsers

### DIFF
--- a/client/src/components/LinkDisplay/Style.module.css
+++ b/client/src/components/LinkDisplay/Style.module.css
@@ -161,7 +161,7 @@
   border-width: 1px;
   font-family: inherit;
   font-size: 18px;
-  width: 100px;
+  width: 110px;
   height: 40px;
   border-radius: 5px;
   cursor: pointer;


### PR DESCRIPTION
100px width is sufficient on PC, but it causes misalignment on mobile phones.

100px:
![photo_2024-08-12_21-09-05](https://github.com/user-attachments/assets/e4bc45c8-4981-4c1e-848a-907788fd8e75)


110px:
![photo_2024-08-12_22-29-24](https://github.com/user-attachments/assets/492f3aa3-3657-4a6e-a3f1-90fbb9d95748)