### PR TITLE
Fixes Copy and QR Code buttons in desktop views

### DIFF
--- a/client/src/components/LinkDisplay/Style.module.css
+++ b/client/src/components/LinkDisplay/Style.module.css
@@ -41,7 +41,7 @@
   border-width: 1px;
   font-family: inherit;
   font-size: 18px;
-  width: 60px;
+  width: 50px;
   height: 40px;
   border-radius: 5px;
   cursor: pointer;

--- a/client/src/components/LinkDisplay/Style.module.css
+++ b/client/src/components/LinkDisplay/Style.module.css
@@ -41,7 +41,7 @@
   border-width: 1px;
   font-family: inherit;
   font-size: 18px;
-  width: 50px;
+  width: 60px;
   height: 40px;
   border-radius: 5px;
   cursor: pointer;
@@ -189,11 +189,11 @@
   }
 
   .copyButton {
-    width: 100px;
+    width: 125px;
   }
 
   .qrButton {
-    width: 100px;
+    width: 125px;
     transform: none;
   }
 


### PR DESCRIPTION
The Copy button once clicked would change from saying "Copy" to "Copied!" which would wrap into another line. This PR increases the width of the buttons from 100px to 125px to account for the change in wording.

**Before**
![Copy_QR_Code_Buttons](https://github.com/user-attachments/assets/03b166c5-62c2-45f0-a721-5ef8a1ba4842)

**After**
![Buttons_Fix](https://github.com/user-attachments/assets/425e3207-e18d-4223-b431-90bbb810f40e)
